### PR TITLE
Remove unnecessary condition for css-in-js

### DIFF
--- a/ui/RootStyleRegistry.tsx
+++ b/ui/RootStyleRegistry.tsx
@@ -25,14 +25,9 @@ export default function RootStyleRegistry({
     );
   });
 
-  // Only include style registry on server side for SSR
-  if (typeof window === 'undefined') {
-    return (
-      <StyledComponentsRegistry>
-        <StyledJsxRegistry>{children}</StyledJsxRegistry>
-      </StyledComponentsRegistry>
-    );
-  }
-
-  return children;
+  return (
+    <StyledComponentsRegistry>
+      <StyledJsxRegistry>{children}</StyledJsxRegistry>
+    </StyledComponentsRegistry>
+  );
 }


### PR DESCRIPTION
No need to strip the condition for not rendering customized css registry on client side. Previously they fallback to the default global registry, but we can use the customized one directly