### PR TITLE
Update to latest canary of Next.js

### DIFF
--- a/app/styling/page.tsx
+++ b/app/styling/page.tsx
@@ -16,7 +16,7 @@ export default function Page() {
               Creating a "style registry" to collect all CSS rules in a render.
             </li>
             <li>
-              Using the new `useFlushEffects` hook to inject rules before any
+              Use the new `useServerInsertedHTML` hook to inject rules before any
               content that might use them.
             </li>
             <li>

--- a/app/styling/styled-components/registry.tsx
+++ b/app/styling/styled-components/registry.tsx
@@ -1,7 +1,7 @@
 'client'
 
 import React from 'react';
-import { useFlushEffects } from 'next/dist/client/components/hooks-client';
+import { useServerInsertedHTML } from 'next/dist/client/components/hooks-client';
 import { useStyledComponentsRegistry } from '@/lib/styling';
 
 export default function StyledComponentsRegistry({
@@ -12,7 +12,7 @@ export default function StyledComponentsRegistry({
   const [StyledComponentsRegistry, styledComponentsFlushEffect] =
     useStyledComponentsRegistry();
 
-  useFlushEffects(() => {
+  useServerInsertedHTML(() => {
     return (
       <>
         {styledComponentsFlushEffect()}

--- a/app/styling/styled-jsx/registry.tsx
+++ b/app/styling/styled-jsx/registry.tsx
@@ -1,7 +1,7 @@
 'client'
 
 import React from 'react';
-import { useFlushEffects } from 'next/dist/client/components/hooks-client';
+import { useServerInsertedHTML } from 'next/dist/client/components/hooks-client';
 import { useStyledJsxRegistry } from '@/lib/styling';
 
 export default function StyledJsxRegistry({
@@ -11,7 +11,7 @@ export default function StyledJsxRegistry({
 }) {
   const [StyledJsxRegistry, styledJsxFlushEffect] = useStyledJsxRegistry();
 
-  useFlushEffects(() => {
+  useServerInsertedHTML(() => {
     return (
       <>
         {styledJsxFlushEffect()}

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "clsx": "1.2.1",
-    "next": "^12.3.2-canary.17",
-    "react": "0.0.0-experimental-3d615fc14-20220919",
-    "react-dom": "0.0.0-experimental-3d615fc14-20220919",
+    "next": "^12.3.2-canary.18",
+    "react": "0.0.0-experimental-cb5084d1c-20220924",
+    "react-dom": "0.0.0-experimental-cb5084d1c-20220924",
     "styled-components": "6.0.0-beta.2",
     "use-count-up": "3.0.1"
   },

--- a/ui/RootStyleRegistry.tsx
+++ b/ui/RootStyleRegistry.tsx
@@ -1,7 +1,7 @@
 'client'
 
 import React from 'react';
-import { useFlushEffects } from 'next/dist/client/components/hooks-client';
+import { useServerInsertedHTML } from 'next/dist/client/components/hooks-client';
 import {
   useStyledComponentsRegistry,
   useStyledJsxRegistry,
@@ -16,7 +16,7 @@ export default function RootStyleRegistry({
     useStyledComponentsRegistry();
   const [StyledJsxRegistry, styledJsxFlushEffect] = useStyledJsxRegistry();
 
-  useFlushEffects(() => {
+  useServerInsertedHTML(() => {
     return (
       <>
         {styledJsxFlushEffect()}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,10 +1091,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@next/env@12.3.2-canary.17":
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.3.2-canary.17.tgz#2f16a09c9f378cb3413d01350ae15f01ae929f54"
-  integrity sha512-EXo+OkgCXrHm0bf+XLQbu5sBAElal7XG3/+NFrtK9EbEIPqflIkg1cQdZUdHelvSEWajXJG5/WWX8MmnjKk1Vw==
+"@next/env@12.3.2-canary.18":
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.3.2-canary.18.tgz#1d17f1632d54e19eab1db6be66f89e2d9e19a92f"
+  integrity sha512-712eGe2h+YIU7BLrPm1Fu6fub0+b/tpXF/B6j5jeClDA7tVVhwKNbIdOVRrYxQAb+eWiZhjBHqn0z5ScK/RUBw==
 
 "@next/eslint-plugin-next@12.3.2-canary.16":
   version "12.3.2-canary.16"
@@ -1103,70 +1103,70 @@
   dependencies:
     glob "7.1.7"
 
-"@next/swc-android-arm-eabi@12.3.2-canary.17":
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.17.tgz#4a9ca468720f02a09fec64a016ed120d0e9eb0b0"
-  integrity sha512-QeJOO1pC3sZxBWjdF9zBLqyCw9y/9Y1f/L4BuOl36t1ppm8fkViKAOBgYxDef8x1R21pgixGHm9Qp7jmD25hsw==
+"@next/swc-android-arm-eabi@12.3.2-canary.18":
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.18.tgz#6633ca1f0bf8831ce7e2d10f1abdc2f6f8ff7d72"
+  integrity sha512-ViYsFq/NoOhvAowg5hdFA+AejazKQ1HVnft1hN+N5PwfsDPpnJEKkh79pBMhos0JyoYQujgRhhdFaODCmj0PVA==
 
-"@next/swc-android-arm64@12.3.2-canary.17":
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.17.tgz#b3a2f8c5df804271c56149d0d9bcf91a891cce5f"
-  integrity sha512-1usBEiiuyB38n0upHTEypLjOnQW1PWGSCiRNGobySUxRVi/AXMQO5L1xbjO3STRo7H8Uklh3iheG8mRBftkYIA==
+"@next/swc-android-arm64@12.3.2-canary.18":
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.18.tgz#8a6864d193c57464e05f0f91ad469ef3e0b7f688"
+  integrity sha512-2l46/3t7eCc0BC6npE99lzQTX/4PjrlWTdUHOUgjaVYHQl+uLTW3L0fdhtTJh8Bi7UJeqn1azkNhBlmMASwnPQ==
 
-"@next/swc-darwin-arm64@12.3.2-canary.17":
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.17.tgz#550a13fc2b9d343d3b6dcff8c23fd5f5729977e9"
-  integrity sha512-Zxqnpc5SQmnBsJ4c3AJhPsPYBWl5yXoe89F92lQMBD7OQB34Rhw8ahugHQWykJiGoSJIOrYZ+v6FEiddsTTQnw==
+"@next/swc-darwin-arm64@12.3.2-canary.18":
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.18.tgz#8fca0370c888268f2200e1f8ccd2448cae8433d4"
+  integrity sha512-YLBGdMUgThfq7SN9QQjddz9e1T5Zn2TrMPURY+tFe4mc+e76A0QsKXhxIkluKA2Gjb+1GWu5HDY3DGQbWcdVsA==
 
-"@next/swc-darwin-x64@12.3.2-canary.17":
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.17.tgz#9abf171d5bc473e7e27a77d2eb040cadb6ca2bff"
-  integrity sha512-VcqS1r+es5d42EjQrm7/JIx1LWZYgWJwqL6mLZtBbnicT43Yqi7KqGTOzVIqznUeRBjsSnNL43iJJhCL1cPqwQ==
+"@next/swc-darwin-x64@12.3.2-canary.18":
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.18.tgz#b0c029a35cb47103a13b5f04ff6fd8f9f53ba335"
+  integrity sha512-Fcp91XNDC7ed+yKzwJT5f39s4r1Hi/okQKc6LTYoyGtNjSUaLnqtSNrJXU5TDJXc4daDFhMu6cUtXUVx1HzEyg==
 
-"@next/swc-freebsd-x64@12.3.2-canary.17":
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.17.tgz#1b03126a42ad0c326779b8321b9cf6832620fabb"
-  integrity sha512-eTbFU5X/ToDCuFXt/vSXizgXUWD/lUojHe1g2IzJz0+E+/npPIytuUOAa6IIND4zoykAujOE0k/UglixE4BDNA==
+"@next/swc-freebsd-x64@12.3.2-canary.18":
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.18.tgz#1e84f4bde9d908f41e60420bd5050fa785539f1e"
+  integrity sha512-Ynd44SsigxZJaJCaf8UlVrBn4a00a5AOIS6/6sHTUBnlMfPYxFeS1zIRQX4c5CdnLAbs2Z19UGF28435+6K50g==
 
-"@next/swc-linux-arm-gnueabihf@12.3.2-canary.17":
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.17.tgz#4e44624fe385decf726d20ab0f2d9d00197e984f"
-  integrity sha512-5DZSV8jjtnptSM1PjKJzqwG9ZNWqPCzv+VXnYffMpNki2wR9QpP+QAGVNf3Vd/BXHWg8hZkbatyO06pVFOf7rQ==
+"@next/swc-linux-arm-gnueabihf@12.3.2-canary.18":
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.18.tgz#920bb4181190d7f47a04e78b8354fb4119e5337b"
+  integrity sha512-/yNcvHtVXDmychj10ePbILHbl46Y2uKolC7FHK0QHFYrbgCYe8r6745puGRZWEoVnUGvgzl2rayoCq43ZRo7tw==
 
-"@next/swc-linux-arm64-gnu@12.3.2-canary.17":
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.17.tgz#4ce8cfd4ddd67533dbfebe58ad715b52aab28c51"
-  integrity sha512-oXez7wsXETgiKzCrsOZi6u2Ur6FR5Ts3wYGMm1smGZ99XFAq5AMoSQqgl8HpnKeR/PboiCjuGI4KhNSAYgUD5Q==
+"@next/swc-linux-arm64-gnu@12.3.2-canary.18":
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.18.tgz#a0f05a0032af0fb451783dad6b6921e9a9fed841"
+  integrity sha512-e3ZafcDDAIdl2eOgkRKlf1n45NtUkhiPS29Jcd5gLpw1KaOjs4e48+Pv+uP6ypaxLGhuUgzD7T/lxLblgwZFzw==
 
-"@next/swc-linux-arm64-musl@12.3.2-canary.17":
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.17.tgz#57d509f61eb51a819c6e69221110a0229b7c9755"
-  integrity sha512-BEfTE2Ni0FPb7vsZ0+Ti9Q/nj9ghuH54hPFAKCU1U6MrVVKqIEVK+p6oQKvCw8LTArwNTmGLfYozlgLojzZoPA==
+"@next/swc-linux-arm64-musl@12.3.2-canary.18":
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.18.tgz#9718f6b9bc5138c40417c1b53cee3fc63aff94c0"
+  integrity sha512-2+p9MUqa0421qj0PxGdxdEXzcY0xh769+5ynnqhHWDj5ZsnjHC2ZfKmtsjB9qu5J/bc9l5TAs6eYjgWuuNeOEQ==
 
-"@next/swc-linux-x64-gnu@12.3.2-canary.17":
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.17.tgz#eaf1357d98cbf1ce6d74ef9f2d019904cef7c98a"
-  integrity sha512-deC/gnNDYiDKtV6skwqKWRf3+Ok++gIxGoUsXxvTYWX1PeV7twYC9u6VP5TAF57fyAlDTkzlMxS1iZbpK6CQVQ==
+"@next/swc-linux-x64-gnu@12.3.2-canary.18":
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.18.tgz#4cd86c03980f470ae761b181e0d20ce73a5bedb0"
+  integrity sha512-Wr1AOHnL3K/vFevFtx5B9ZV/AzKzzHT3p16gaPQLDmdDyfJEGEeQFAHecBRoEfWev+OK9QBv6rkgS1Ft1t1cPg==
 
-"@next/swc-linux-x64-musl@12.3.2-canary.17":
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.17.tgz#df7f18b5826c3c7f1f7d18c16ba895c986e2e016"
-  integrity sha512-GknEVtX7Xu/ShRfoqtZCmKk06BOrBJsNC2f8f0FHMhMJ0FwIWx3GV0JRQyXUyFhB+yXI1OWjDGNCBVWHtd2+Vw==
+"@next/swc-linux-x64-musl@12.3.2-canary.18":
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.18.tgz#ee6e9f9b5a3391f4722276a37ec1d7f0c6b39989"
+  integrity sha512-cKcu4+Kwcc1O6fIE4/BW/Ppj4aba2zP0fkuE6VTT86/4SKUjheGnwIgTIXdNWN330at+nq+DqIKUCBdaM4dm3Q==
 
-"@next/swc-win32-arm64-msvc@12.3.2-canary.17":
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.17.tgz#422992c6dbec43a2eb418611f8781a7f1dbab85b"
-  integrity sha512-GwQCiAh4gnvxZwBq96RywqTueULthdBBcNM2SW83ONEg/9hAEKYbSJPQOLKhidwL10Nha+Mpz2gnJ3iFu3rtOQ==
+"@next/swc-win32-arm64-msvc@12.3.2-canary.18":
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.18.tgz#2ec7fccf9d09d12b0c86cd0262703e2f69b1b00a"
+  integrity sha512-jh/wuXESuirHm09EtXasw3ts6vdMLT7LbR2Ad/6VHH+xgCPW0XXeDVXHmaRtqEX3Cd/z+Yi23oz/zrnjxCKimQ==
 
-"@next/swc-win32-ia32-msvc@12.3.2-canary.17":
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.17.tgz#507ef80601f45c60465407e05e5ac368adb48822"
-  integrity sha512-j3RiaO7MN6phgh6XbTJhP/g1FSzvxf70QDYPjPHCVKMKxuJXDkFcuKHmhgRU1YX3eEmc71jDlzL0J/QYlCbUlw==
+"@next/swc-win32-ia32-msvc@12.3.2-canary.18":
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.18.tgz#d023a43cf2ddd7939a1502b095b647af2f3eb9d3"
+  integrity sha512-QcgzmBEaKoQn9JYqb1YV82d0szeufyVsM7XY2W8BwPCodcQPVhxfqYuOBshTo1V7PRg4iqU+Z6PuUd0gcQnOmg==
 
-"@next/swc-win32-x64-msvc@12.3.2-canary.17":
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.17.tgz#ed0f047a6096f08f6d41e5800a50754e9113a3bb"
-  integrity sha512-ePn9BMvWcgC39oaXV6r8FrfQJwB5wQBIVJlllyGuE4FYmsYRO1X9tnOJKVSVQE9JwLVXrrvKdr8dOTcLv3AAEQ==
+"@next/swc-win32-x64-msvc@12.3.2-canary.18":
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.18.tgz#69453bff21c4ea50305958967bfec76192865a3e"
+  integrity sha512-adajLfIMlaIVpbUhhdBjTVsOzKp2agxZXW6SUOlc33k48rSPF94kCsvMnV/llDpNAnk0ZON0fyxChBAXCjD3uw==
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"
@@ -2589,31 +2589,31 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-next@^12.3.2-canary.17:
-  version "12.3.2-canary.17"
-  resolved "https://registry.yarnpkg.com/next/-/next-12.3.2-canary.17.tgz#73eaa87fe1d8220b8a28043fb12fee0111bff697"
-  integrity sha512-K+3kK2zFbwYwfV8a1PLKHD7IC5AWzCF6HwryXvksWWl85aKlmR00DcfCNhiT1gAaqdg9GACPNDU6TX+nFFQwGg==
+next@^12.3.2-canary.18:
+  version "12.3.2-canary.18"
+  resolved "https://registry.yarnpkg.com/next/-/next-12.3.2-canary.18.tgz#e4b7b2c056170696b89c5bea1e234ac24088bf3c"
+  integrity sha512-t0b750k00CAnV6yZaaoTAn4BeNrh31giGua0BDcCrrTeqPWb85meXJgsGO7yNT72hs05W5vTz1oK2MN5HSREDQ==
   dependencies:
-    "@next/env" "12.3.2-canary.17"
+    "@next/env" "12.3.2-canary.18"
     "@swc/helpers" "0.4.11"
     caniuse-lite "^1.0.30001406"
     postcss "8.4.14"
     styled-jsx "5.0.7"
     use-sync-external-store "1.2.0"
   optionalDependencies:
-    "@next/swc-android-arm-eabi" "12.3.2-canary.17"
-    "@next/swc-android-arm64" "12.3.2-canary.17"
-    "@next/swc-darwin-arm64" "12.3.2-canary.17"
-    "@next/swc-darwin-x64" "12.3.2-canary.17"
-    "@next/swc-freebsd-x64" "12.3.2-canary.17"
-    "@next/swc-linux-arm-gnueabihf" "12.3.2-canary.17"
-    "@next/swc-linux-arm64-gnu" "12.3.2-canary.17"
-    "@next/swc-linux-arm64-musl" "12.3.2-canary.17"
-    "@next/swc-linux-x64-gnu" "12.3.2-canary.17"
-    "@next/swc-linux-x64-musl" "12.3.2-canary.17"
-    "@next/swc-win32-arm64-msvc" "12.3.2-canary.17"
-    "@next/swc-win32-ia32-msvc" "12.3.2-canary.17"
-    "@next/swc-win32-x64-msvc" "12.3.2-canary.17"
+    "@next/swc-android-arm-eabi" "12.3.2-canary.18"
+    "@next/swc-android-arm64" "12.3.2-canary.18"
+    "@next/swc-darwin-arm64" "12.3.2-canary.18"
+    "@next/swc-darwin-x64" "12.3.2-canary.18"
+    "@next/swc-freebsd-x64" "12.3.2-canary.18"
+    "@next/swc-linux-arm-gnueabihf" "12.3.2-canary.18"
+    "@next/swc-linux-arm64-gnu" "12.3.2-canary.18"
+    "@next/swc-linux-arm64-musl" "12.3.2-canary.18"
+    "@next/swc-linux-x64-gnu" "12.3.2-canary.18"
+    "@next/swc-linux-x64-musl" "12.3.2-canary.18"
+    "@next/swc-win32-arm64-msvc" "12.3.2-canary.18"
+    "@next/swc-win32-ia32-msvc" "12.3.2-canary.18"
+    "@next/swc-win32-x64-msvc" "12.3.2-canary.18"
 
 node-releases@^2.0.5, node-releases@^2.0.6:
   version "2.0.6"
@@ -2887,23 +2887,23 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-react-dom@0.0.0-experimental-3d615fc14-20220919:
-  version "0.0.0-experimental-3d615fc14-20220919"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.0.0-experimental-3d615fc14-20220919.tgz#bde9d9e84328b4b924cefe346b46b068f1a018d5"
-  integrity sha512-zn0M6Pv+EDV0qWXJLvGwG/NLJo3bI7FoFLFAG9llA+tcuMazTt4xeLG0m7LMrsrSjDXGCfM5EBb8w3IcmRDOuQ==
+react-dom@0.0.0-experimental-cb5084d1c-20220924:
+  version "0.0.0-experimental-cb5084d1c-20220924"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.0.0-experimental-cb5084d1c-20220924.tgz#7a8334c5cf4baeb5651ca76fc9eb92ebbaf223bf"
+  integrity sha512-0IHzPGHESn3uu8nI1w5596GX8bCGCE94DpaHkKSGWOlB6uhoVecU0fyOCkkNuB4cMc9WeOWiH2gsM100EWZDPQ==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "0.0.0-experimental-3d615fc14-20220919"
+    scheduler "0.0.0-experimental-cb5084d1c-20220924"
 
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react@0.0.0-experimental-3d615fc14-20220919:
-  version "0.0.0-experimental-3d615fc14-20220919"
-  resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-experimental-3d615fc14-20220919.tgz#ec2d47c4fe526a90009ac1ff4306f7033747cd85"
-  integrity sha512-dZBD2RkSAW6qi6Xunn7ZOGJ/0kvcIQbr0KqGuFFOc5xRMYVUDha0xj7iyknZuJJxOYAi/PttOXhmrFkYWOpSbw==
+react@0.0.0-experimental-cb5084d1c-20220924:
+  version "0.0.0-experimental-cb5084d1c-20220924"
+  resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-experimental-cb5084d1c-20220924.tgz#ab661af674be824ae2989467506443b8bc4318d3"
+  integrity sha512-66AdfxkJrwCaCEKT0LQRd9J9GQ9T+yN7Wx9XT+tNxKycYQ0Exm+DZxOTedagWDlsFMXroyhrTWzgdC18R2PaOQ==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -3030,10 +3030,10 @@ safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-scheduler@0.0.0-experimental-3d615fc14-20220919:
-  version "0.0.0-experimental-3d615fc14-20220919"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.0.0-experimental-3d615fc14-20220919.tgz#a78fd8a4c10ace88e7ba7287e75eab4e43e10a69"
-  integrity sha512-iVqdQ+UqbJCZ3JfwNVXTm3KOVBbmMGxEHqzbooYK4vL0V2WuF3kpbCzT09qLEeTEjo6/U1ym8Q3NJbpJ5lsBsQ==
+scheduler@0.0.0-experimental-cb5084d1c-20220924:
+  version "0.0.0-experimental-cb5084d1c-20220924"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.0.0-experimental-cb5084d1c-20220924.tgz#9986680e1fbf7e4ccfe7606fef5920939d3a1abe"
+  integrity sha512-SeszKCdhM5OHxNMStjpKIAaloARUMZqIpDZjkZeGuRsyr7YlAqvlsCXyee4ZQOOU1pbr7BIvQntKy5Hil+DQJA==
   dependencies:
     loose-envify "^1.1.0"
 


### PR DESCRIPTION
This updates to the latest canary of Next.js and latest working experimental react version. Also updates `useFlushEffects` to `useServerInsertedHTML` as it has been renamed. 