### PR TITLE
Update to latest canary of Next.js

### DIFF
--- a/app/GlobalNav.tsx
+++ b/app/GlobalNav.tsx
@@ -2,7 +2,7 @@
 
 import { demos } from '@/lib/demos';
 import clsx from 'clsx';
-import { useSelectedLayoutSegment } from 'next/dist/client/components/hooks-client';
+import { useSelectedLayoutSegment } from 'next/navigation';
 import Link from 'next/link';
 
 export default function GlobalNav() {

--- a/app/components/CategoryNav.tsx
+++ b/app/components/CategoryNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { TabNavItem } from '@/ui/TabNavItem';
-import { useSelectedLayoutSegment } from 'next/dist/client/components/hooks-client';
+import { useSelectedLayoutSegment } from 'next/navigation';
 
 const CategoryNav = () => {
   const selectedLayoutSegment = useSelectedLayoutSegment();

--- a/app/components/SubCategoryNav.tsx
+++ b/app/components/SubCategoryNav.tsx
@@ -2,7 +2,7 @@
 
 import { type Category } from '@/lib/getCategories';
 import { TabNavItem } from '@/ui/TabNavItem';
-import { useSelectedLayoutSegment } from 'next/dist/client/components/hooks-client';
+import { useSelectedLayoutSegment } from 'next/navigation';
 
 const SubCategoryNav = ({ category }: { category: Category }) => {
   const selectedLayoutSegment = useSelectedLayoutSegment();

--- a/app/error-handling/CategoryNav.tsx
+++ b/app/error-handling/CategoryNav.tsx
@@ -2,7 +2,7 @@
 
 import { type Category } from '@/lib/getCategories';
 import { TabNavItem } from '@/ui/TabNavItem';
-import { useSelectedLayoutSegment } from 'next/dist/client/components/hooks-client';
+import { useSelectedLayoutSegment } from 'next/navigation';
 
 const CategoryNav = ({ categories }: { categories: Category[] }) => {
   const selectedLayoutSegment = useSelectedLayoutSegment();

--- a/app/error-handling/[categorySlug]/SubCategoryNav.tsx
+++ b/app/error-handling/[categorySlug]/SubCategoryNav.tsx
@@ -2,7 +2,7 @@
 
 import { type Category } from '@/lib/getCategories';
 import { TabNavItem } from '@/ui/TabNavItem';
-import { useSelectedLayoutSegment } from 'next/dist/client/components/hooks-client';
+import { useSelectedLayoutSegment } from 'next/navigation';
 
 const SubCategoryNav = ({ category }: { category: Category }) => {
   const selectedLayoutSegment = useSelectedLayoutSegment();

--- a/app/hooks/CategoryNav.tsx
+++ b/app/hooks/CategoryNav.tsx
@@ -2,7 +2,7 @@
 
 import { type Category } from '@/lib/getCategories';
 import { TabNavItem } from '@/ui/TabNavItem';
-import { useSelectedLayoutSegment } from 'next/dist/client/components/hooks-client';
+import { useSelectedLayoutSegment } from 'next/navigation';
 
 const CategoryNav = ({ categories }: { categories: Category[] }) => {
   const selectedLayoutSegment = useSelectedLayoutSegment();

--- a/app/hooks/[categorySlug]/SubCategoryNav.tsx
+++ b/app/hooks/[categorySlug]/SubCategoryNav.tsx
@@ -2,7 +2,7 @@
 
 import { type Category } from '@/lib/getCategories';
 import { TabNavItem } from '@/ui/TabNavItem';
-import { useSelectedLayoutSegment } from 'next/dist/client/components/hooks-client';
+import { useSelectedLayoutSegment } from 'next/navigation';
 
 const SubCategoryNav = ({ category }: { category: Category }) => {
   const selectedLayoutSegment = useSelectedLayoutSegment();

--- a/app/layouts/CategoryNav.tsx
+++ b/app/layouts/CategoryNav.tsx
@@ -2,7 +2,7 @@
 
 import { type Category } from '@/lib/getCategories';
 import { TabNavItem } from '@/ui/TabNavItem';
-import { useSelectedLayoutSegment } from 'next/dist/client/components/hooks-client';
+import { useSelectedLayoutSegment } from 'next/navigation';
 
 const CategoryNav = ({ categories }: { categories: Category[] }) => {
   const selectedLayoutSegment = useSelectedLayoutSegment();

--- a/app/layouts/[categorySlug]/SubCategoryNav.tsx
+++ b/app/layouts/[categorySlug]/SubCategoryNav.tsx
@@ -2,7 +2,7 @@
 
 import { type Category } from '@/lib/getCategories';
 import { TabNavItem } from '@/ui/TabNavItem';
-import { useSelectedLayoutSegment } from 'next/dist/client/components/hooks-client';
+import { useSelectedLayoutSegment } from 'next/navigation';
 
 const SubCategoryNav = ({ category }: { category: Category }) => {
   const selectedLayoutSegment = useSelectedLayoutSegment();

--- a/app/loading/CategoryNav.tsx
+++ b/app/loading/CategoryNav.tsx
@@ -2,7 +2,7 @@
 
 import { type Category } from '@/lib/getCategories';
 import { TabNavItem } from '@/ui/TabNavItem';
-import { useSelectedLayoutSegment } from 'next/dist/client/components/hooks-client';
+import { useSelectedLayoutSegment } from 'next/navigation';
 
 const CategoryNav = ({ categories }: { categories: Category[] }) => {
   const selectedLayoutSegment = useSelectedLayoutSegment();

--- a/app/route-groups/(shop)/[categorySlug]/SubCategoryNav.tsx
+++ b/app/route-groups/(shop)/[categorySlug]/SubCategoryNav.tsx
@@ -2,7 +2,7 @@
 
 import { type Category } from '@/lib/getCategories';
 import { TabNavItem } from '@/ui/TabNavItem';
-import { useSelectedLayoutSegment } from 'next/dist/client/components/hooks-client';
+import { useSelectedLayoutSegment } from 'next/navigation';
 
 const SubCategoryNav = ({ category }: { category: Category }) => {
   const selectedLayoutSegment = useSelectedLayoutSegment();

--- a/app/route-groups/CategoryNav.tsx
+++ b/app/route-groups/CategoryNav.tsx
@@ -2,7 +2,7 @@
 
 import { type Category } from '@/lib/getCategories';
 import { TabNavItem } from '@/ui/TabNavItem';
-import { useSelectedLayoutSegment } from 'next/dist/client/components/hooks-client';
+import { useSelectedLayoutSegment } from 'next/navigation';
 
 const CategoryNav = ({ categories }: { categories: Category[] }) => {
   const selectedLayoutSegment = useSelectedLayoutSegment();

--- a/app/styling/StylingNav.tsx
+++ b/app/styling/StylingNav.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { TabNavItem } from '@/ui/TabNavItem';
-import { useSelectedLayoutSegment } from 'next/dist/client/components/hooks-client';
+import { useSelectedLayoutSegment } from 'next/navigation';
 
 const items = [
   {

--- a/app/styling/styled-components/registry.tsx
+++ b/app/styling/styled-components/registry.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { useServerInsertedHTML } from 'next/dist/client/components/hooks-client';
+import { useServerInsertedHTML } from 'next/navigation';
 import { useStyledComponentsRegistry } from '@/lib/styling';
 
 export default function StyledComponentsRegistry({

--- a/app/styling/styled-jsx/registry.tsx
+++ b/app/styling/styled-jsx/registry.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { useServerInsertedHTML } from 'next/dist/client/components/hooks-client';
+import { useServerInsertedHTML } from 'next/navigation';
 import { useStyledJsxRegistry } from '@/lib/styling';
 
 export default function StyledJsxRegistry({

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "clsx": "1.2.1",
-    "next": "12.3.2-canary.26",
+    "next": "12.3.2-canary.28",
     "react": "0.0.0-experimental-5d60a0b84-20221006",
     "react-dom": "0.0.0-experimental-5d60a0b84-20221006",
     "styled-components": "6.0.0-beta.2",

--- a/ui/AddressBar.tsx
+++ b/ui/AddressBar.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {
   usePathname,
   useSearchParams,
-} from 'next/dist/client/components/hooks-client';
+} from 'next/navigation';
 
 const AddressBar = () => {
   const pathname = usePathname();

--- a/ui/HooksClient.tsx
+++ b/ui/HooksClient.tsx
@@ -6,7 +6,7 @@ import {
   useSelectedLayoutSegment,
   useSearchParams,
   useSearchParam,
-} from 'next/dist/client/components/hooks-client';
+} from 'next/navigation';
 
 const HooksClient = () => {
   const pathname = usePathname();

--- a/ui/HooksServer.tsx
+++ b/ui/HooksServer.tsx
@@ -3,7 +3,7 @@ import {
   cookies,
   headers,
   previewData,
-} from 'next/dist/client/components/hooks-server';
+} from 'next/headers';
 
 const HooksServer = () => {
   return (

--- a/ui/RootStyleRegistry.tsx
+++ b/ui/RootStyleRegistry.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { useServerInsertedHTML } from 'next/dist/client/components/hooks-client';
+import { useServerInsertedHTML } from 'next/navigation';
 import {
   useStyledComponentsRegistry,
   useStyledJsxRegistry,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,10 +1091,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@next/env@12.3.2-canary.26":
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.3.2-canary.26.tgz#9be577402d01ded0195dfb8f490f6552830a9e56"
-  integrity sha512-13+wv09AkpPJNSuUk7tUb5R1k77ITdN5myuh46ciLiWxz7ahXf050B1YSOwmaR9s+XDAquVcfkEwZP5qra+QkQ==
+"@next/env@12.3.2-canary.28":
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.3.2-canary.28.tgz#8e648b57951b1378537dd0d582dd1a349c0b3f18"
+  integrity sha512-q1ueMCKvS27IBaUZobMkv+1eS0484JrPlZWr78cDkS0sqZZAbjQVpDyGH8cq6nyX0MXDHm3kNuXjdpyH6uUpwA==
 
 "@next/eslint-plugin-next@12.3.2-canary.16":
   version "12.3.2-canary.16"
@@ -1103,70 +1103,70 @@
   dependencies:
     glob "7.1.7"
 
-"@next/swc-android-arm-eabi@12.3.2-canary.26":
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.26.tgz#0b9a9930cf85a0ddfd4855a0b84b747d3dd153ec"
-  integrity sha512-eqNv4gn/vv9dRo0ve3jHNcFUv7ylGIdSVfhG4qQJGJRBWGvpckhB2Cqxo/ivXKrw/rv8ntu63yWoYdPOrIIZ8g==
+"@next/swc-android-arm-eabi@12.3.2-canary.28":
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.2-canary.28.tgz#ec52772fede0f69bbbb8b833cd63f7fab8ed714c"
+  integrity sha512-eFRKzd304qAQsadPVuR35OVEYi9vdpaxK+J943dFY9S30dMaemDde8imXVxXxm0mUxe3Okq46BFU4XewqY4wxw==
 
-"@next/swc-android-arm64@12.3.2-canary.26":
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.26.tgz#a4b7693050fe3d7f5267efa921922f8192d7a9d1"
-  integrity sha512-zS1/YNXPNK7YCBFo5dCVHYYHeGFc83uDwJA+Qg8QG7SplRDKgCKElwsmbCsaXekoC7JqKcpK1qq6aysdybR/4Q==
+"@next/swc-android-arm64@12.3.2-canary.28":
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.3.2-canary.28.tgz#32727daaa83f34d9a04c9a236341c3634f5da9ad"
+  integrity sha512-P4GNhOVQNqE88akuPCjKUMP3lFW49rvFeIgv1XmL5I2/CGd2eWOq7qwxS1Y4RvthRk3zqhMbuKTSok3GTzaa9Q==
 
-"@next/swc-darwin-arm64@12.3.2-canary.26":
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.26.tgz#04842bdced2d90f26a1e9a246b804cfd5ec70cd5"
-  integrity sha512-bJuDBMq1nzcBQkqFAGqAS7DYM4wE7SlMa3SwVe0vAIRfA2ls4NI3dfnuuqVV4BZmxIGKyHB/XN6Z7ZIfbs1N+Q==
+"@next/swc-darwin-arm64@12.3.2-canary.28":
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.2-canary.28.tgz#b9bcdedc9cc0ea4e86d005c21e7c1df6bd2606fe"
+  integrity sha512-ipOc7Nx8FAWwfxwHcRPQyPEb8IiYPypd/OedOm3cPTcwJe1lkAkjKDmQJs7JdD0CbbajEq8msyhztDAorsL9jg==
 
-"@next/swc-darwin-x64@12.3.2-canary.26":
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.26.tgz#db10efc572921224a488ae8a227930fb94f61073"
-  integrity sha512-zHULUCEoHLISNfNDiL3kKEbY+qPAw8lLee0SsfqalUTAcSM/Aa+Nurn+iTkj7niyBw9tvbeYkSfWMeketBtZqg==
+"@next/swc-darwin-x64@12.3.2-canary.28":
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.2-canary.28.tgz#5c946ca191397e2255bb9c25a60b389bc9fa5e17"
+  integrity sha512-lPPxC/T1uUErJdc7jT8Vvt/rtblFn/ff3svO/yxdHAIljIKFXn3OplMu/zYPFqQ0joJXIjw1/U+2NtdfDte3kg==
 
-"@next/swc-freebsd-x64@12.3.2-canary.26":
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.26.tgz#6abca0843268939d301a705e33057f04ece0746d"
-  integrity sha512-TysWhswEd8Gbg9tdvjNC3VjvGk3cn/TI33Aac+1/2vVLutJny6KsV+zd8jSocr3bzaP595CrT6UTgR+mibk6Cg==
+"@next/swc-freebsd-x64@12.3.2-canary.28":
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.2-canary.28.tgz#607a7bfec9460d5326a1d0902873499f33c853ee"
+  integrity sha512-mCEMprvEuMxY036p5fNwfysZmVyL8WJK8S48rDaAPbDTPYwyUROzrVWeznPKDEZyK4lce+fT8zd7nJzZT8PvsA==
 
-"@next/swc-linux-arm-gnueabihf@12.3.2-canary.26":
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.26.tgz#832f0bc17f97b17ee8b66b29e3ccb2411d8d2b68"
-  integrity sha512-L8DDClRLesW3uwMfIMrTMrT3XcHRv8GuwfCCMxVdwd7PhFlj4eOPwQZHF3UBfH42NNmnNEsLIY+JtdAkTQ++aA==
+"@next/swc-linux-arm-gnueabihf@12.3.2-canary.28":
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.2-canary.28.tgz#4b782b56064dd88a25ab6cd281265de86392758e"
+  integrity sha512-7oJuSOE5Lok4hSwm39h5XvfXTeI7lZpof7k6lFX+g9Gl4jxT+DWQBvMhafUDCOZ5DLsVHqcTVOybzkYCoaVndA==
 
-"@next/swc-linux-arm64-gnu@12.3.2-canary.26":
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.26.tgz#4050451e72578ec609041745dfac033cfc9c7ab6"
-  integrity sha512-YleK6xh2afCl3oKrSp/MBiwHhdTU44HPRuopKf7lP4MWYd+lzruZxzS3Oa71ad/H80KUNhoiO4aHW4Xf0laxYA==
+"@next/swc-linux-arm64-gnu@12.3.2-canary.28":
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.2-canary.28.tgz#9b1f1fb255e8f58801b9e2373c4b0347c4cbc478"
+  integrity sha512-EXgkU6rI8NQE/feNDm7JHKFgZycFnc9xISpEG8GbL+LMe0M+3c50A/iDmF/BAnj9a4XiAk9Y7VbvX1qgSlPDZA==
 
-"@next/swc-linux-arm64-musl@12.3.2-canary.26":
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.26.tgz#916a69fecdebb73061c047df875195863c6c5d51"
-  integrity sha512-X98+/ip6xgn29m0WmjEgXVIFCgZbbQt9Bmo0OL7odrStLc3GiaK6j3Wn7HMoDG8At5Gvj4Lb4UStgL2nW3mn6Q==
+"@next/swc-linux-arm64-musl@12.3.2-canary.28":
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.2-canary.28.tgz#0e10722bb495c95aad6526b3d5f64e71c456b85b"
+  integrity sha512-xA5+zm1NY0tEsVCHqpo6hbwDzwxaMeDSeRqu2lVNVX14A93OM75LdHfNjXqDUgqSyqYMUUJ/YOnzmVqHhsBwuw==
 
-"@next/swc-linux-x64-gnu@12.3.2-canary.26":
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.26.tgz#43c5a3e6a137f270c2d2ae3d5deb3d2bb3c54de7"
-  integrity sha512-K1ihqWUM39xWZLDt3Wfdik/C2XEEde1tyP9XLEOFyPx0J+kUCJsQJBdhay1sBGzv9N42tFFpTKMKF0ts4PVt8w==
+"@next/swc-linux-x64-gnu@12.3.2-canary.28":
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.2-canary.28.tgz#f3aa8da3373b280b6d20068f46d9bf19a77a0c71"
+  integrity sha512-HU3j82+MXljMyIVMajQYezTQsZ4vj/tVV/+qt2TjfM8o+DEYSc+Ibd77mxY4RRK+A/IRO+ok7a73cHkLtp3WCw==
 
-"@next/swc-linux-x64-musl@12.3.2-canary.26":
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.26.tgz#6b5f5d6f4e89a5feb530051f96c2e0fe31f1f1e4"
-  integrity sha512-l2KVvtRwtx6cyreKD5Llb5SkUUe3OYEJ9SqFN/vGYqvV7Yb/xuqagimQVb8rhSuhYG9KMpD3ed9kyotGFED0HQ==
+"@next/swc-linux-x64-musl@12.3.2-canary.28":
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.2-canary.28.tgz#786e1398092d6f363a2ecce9b8587d9fa778e970"
+  integrity sha512-jvLBy3YCytmXrZpHgqBDcDnjwD1n/vNI3zE/vR594hBsSRkSl8u1nL6N284caKVq84y2b77bwwUddwXlBJfypQ==
 
-"@next/swc-win32-arm64-msvc@12.3.2-canary.26":
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.26.tgz#779337e1a31a74939dd2b941aee9732216185b0b"
-  integrity sha512-uk+3pKaGaJtz3uzAORYznnGz1JmJdQKT0DBnDsxEbCzgZWekHo/E8jCo+KNxEnR1uEV5xHyydgBw4k0PN4QfrA==
+"@next/swc-win32-arm64-msvc@12.3.2-canary.28":
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.2-canary.28.tgz#9e886e5943282ebaf1174a37487dc87e9b0a5b6b"
+  integrity sha512-i4H0LWsXenl0YTIyVFY7d/wxuppSQK3nlfTYWCXbIgqFYqtc68S/uZPle1KLIFHNn4etx/8qEKbbgSgCUC/uzQ==
 
-"@next/swc-win32-ia32-msvc@12.3.2-canary.26":
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.26.tgz#f51c6f00404b73ad2eb776f875c189c082b00470"
-  integrity sha512-rSqOVz9TVwhSRkOMzB3D2DjXaeqnkcED8nTxT0jCEZb6AeUNSMTlz+xmaPkWqv+ASkF16YLtXWuC3khJO1pEyA==
+"@next/swc-win32-ia32-msvc@12.3.2-canary.28":
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.2-canary.28.tgz#d46d492d84b2ef251536b9532ccb88434fe23852"
+  integrity sha512-jExfxHdmUTejDLiJOr6ELLpMIAQWsOSXk5mno9YOznysJUMV5EM3gYqz8Ia0pGKwNqwqHOUaVQAK++y6ghxLGQ==
 
-"@next/swc-win32-x64-msvc@12.3.2-canary.26":
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.26.tgz#7f6331d9150f90fba94881d42154cdcfca101a30"
-  integrity sha512-18qv+zzpGdQ+AIimF7/OucARHZ7nzNnGI7oD4+j5PYHSdFWeuuHyKm2cb+aWpweBKR4VwyN+YPGi6mubEHbi1g==
+"@next/swc-win32-x64-msvc@12.3.2-canary.28":
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.2-canary.28.tgz#37687bf81ef564b176550807c75221f70e1a83d9"
+  integrity sha512-SH1fQKToaPB1fMKFTY1/bCGzsLBGdBsPMB3JcZ8nIojSF2LMuRBqH/u7wyUbR5UZ8DyjfAuaF+BDmIty5bFBsg==
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"
@@ -2589,31 +2589,31 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-next@12.3.2-canary.26:
-  version "12.3.2-canary.26"
-  resolved "https://registry.yarnpkg.com/next/-/next-12.3.2-canary.26.tgz#ba93c400a5e815be4e76879a25dbbc4e453b4a51"
-  integrity sha512-6qnLbBfJcqxb6aNTve0qjj0m0Hm35yOzYroOpADCfYQ1UVNp98ittuCtwFk98fQi9FHTI4ecj54L4EDOTcJWeg==
+next@12.3.2-canary.28:
+  version "12.3.2-canary.28"
+  resolved "https://registry.yarnpkg.com/next/-/next-12.3.2-canary.28.tgz#64e3b3e732ff3a3f71c6cd36e466077b2bec34f5"
+  integrity sha512-DN1UbGnILF/RtJ/4r2SrVF4XKBr+B74dghcvKgm643MCjK0udzvxVevF3hEgAL9Oq+lz9y9tIGaA/E+O9QvVVQ==
   dependencies:
-    "@next/env" "12.3.2-canary.26"
+    "@next/env" "12.3.2-canary.28"
     "@swc/helpers" "0.4.11"
     caniuse-lite "^1.0.30001406"
     postcss "8.4.14"
     styled-jsx "5.0.7"
     use-sync-external-store "1.2.0"
   optionalDependencies:
-    "@next/swc-android-arm-eabi" "12.3.2-canary.26"
-    "@next/swc-android-arm64" "12.3.2-canary.26"
-    "@next/swc-darwin-arm64" "12.3.2-canary.26"
-    "@next/swc-darwin-x64" "12.3.2-canary.26"
-    "@next/swc-freebsd-x64" "12.3.2-canary.26"
-    "@next/swc-linux-arm-gnueabihf" "12.3.2-canary.26"
-    "@next/swc-linux-arm64-gnu" "12.3.2-canary.26"
-    "@next/swc-linux-arm64-musl" "12.3.2-canary.26"
-    "@next/swc-linux-x64-gnu" "12.3.2-canary.26"
-    "@next/swc-linux-x64-musl" "12.3.2-canary.26"
-    "@next/swc-win32-arm64-msvc" "12.3.2-canary.26"
-    "@next/swc-win32-ia32-msvc" "12.3.2-canary.26"
-    "@next/swc-win32-x64-msvc" "12.3.2-canary.26"
+    "@next/swc-android-arm-eabi" "12.3.2-canary.28"
+    "@next/swc-android-arm64" "12.3.2-canary.28"
+    "@next/swc-darwin-arm64" "12.3.2-canary.28"
+    "@next/swc-darwin-x64" "12.3.2-canary.28"
+    "@next/swc-freebsd-x64" "12.3.2-canary.28"
+    "@next/swc-linux-arm-gnueabihf" "12.3.2-canary.28"
+    "@next/swc-linux-arm64-gnu" "12.3.2-canary.28"
+    "@next/swc-linux-arm64-musl" "12.3.2-canary.28"
+    "@next/swc-linux-x64-gnu" "12.3.2-canary.28"
+    "@next/swc-linux-x64-musl" "12.3.2-canary.28"
+    "@next/swc-win32-arm64-msvc" "12.3.2-canary.28"
+    "@next/swc-win32-ia32-msvc" "12.3.2-canary.28"
+    "@next/swc-win32-x64-msvc" "12.3.2-canary.28"
 
 node-releases@^2.0.5, node-releases@^2.0.6:
   version "2.0.6"


### PR DESCRIPTION
Also renames `hooks-client` and `hooks-server` imports per https://github.com/vercel/next.js/pull/41368