### PR TITLE
Stringifiable URL search params for `useSearchParams`

### DIFF
--- a/ui/HooksClient.tsx
+++ b/ui/HooksClient.tsx
@@ -20,7 +20,7 @@ const HooksClient = () => {
           {
             usePathname: pathname,
             selectedLayoutSegments: selectedLayoutSegments,
-            useSearchParams: searchParams,
+            useSearchParams: Object.fromEntries(searchParams.entries()),
             "useSearchParam('key')": searchParam,
             useRouter: {
               push: '(string) => void',


### PR DESCRIPTION
`URLSearchParams` is not stringifiable via `JSON`, so there is only an empty object shown on the site:

e.g. `https://app-dir.vercel.app/hooks`: 

![image](https://user-images.githubusercontent.com/29319414/198091716-87e7209c-2dd7-483b-b2a6-87d391917a3b.png)



This change instead gets all entries (which returns an `Iterator`) and create an object out of it that can be stringified.