### PR TITLE
Fix ISR, SSG and SSR learn more links

### DIFF
--- a/app/isr/page.tsx
+++ b/app/isr/page.tsx
@@ -20,7 +20,7 @@ export default function Page() {
       <div>
         <a
           className="font-medium text-zinc-300 hover:text-white"
-          href="https://beta.nextjs.org/docs/routing/loading-ui"
+          href="https://beta.nextjs.org/docs/data-fetching/fetching#revalidating-data"
         >
           Learn more
         </a>

--- a/app/ssg/page.tsx
+++ b/app/ssg/page.tsx
@@ -20,7 +20,7 @@ export default function Page() {
       <div>
         <a
           className="font-medium text-zinc-300 hover:text-white"
-          href="https://beta.nextjs.org/docs/routing/loading-ui"
+          href="https://beta.nextjs.org/docs/data-fetching/fetching#static-data"
         >
           Learn more
         </a>

--- a/app/ssr/page.tsx
+++ b/app/ssr/page.tsx
@@ -25,7 +25,7 @@ export default function Page() {
       <div>
         <a
           className="font-medium text-zinc-300 hover:text-white"
-          href="https://beta.nextjs.org/docs/routing/loading-ui"
+          href="https://beta.nextjs.org/docs/data-fetching/fetching#dynamic-data"
         >
           Learn more
         </a>


### PR DESCRIPTION
Hi,

I might be wrong, but I think the "Learn More" href on the ISR, SSG and SSR pages are incorrect.
It is currently linked to the "Loading UI" documentation, but I think the "Data Fetching" docs explain it better.

Thank you for this playground. It explains really well the new features of NextJS 13

