### PR TITLE
Updated "Learn More" link for error handling

### DIFF
--- a/app/error-handling/page.tsx
+++ b/app/error-handling/page.tsx
@@ -29,7 +29,7 @@ export default function Page() {
       <div>
         <a
           className="font-medium text-zinc-300 hover:text-white"
-          href="https://beta.nextjs.org/docs/routing/loading-ui"
+          href="https://beta.nextjs.org/docs/routing/error-handling"
         >
           Learn more
         </a>


### PR DESCRIPTION
I believe that the `Learn More` link for error handling may be wrong
It currently links to [loading ui](https://beta.nextjs.org/docs/routing/loading-ui) while I think linking it to [error handling](https://beta.nextjs.org/docs/routing/error-handling) may be more appropriate