### PR TITLE
Fix styled-components integration

### DIFF
--- a/app/styling/styled-components/registry.tsx
+++ b/app/styling/styled-components/registry.tsx
@@ -19,7 +19,7 @@ export default function StyledComponentsRegistry({
     return <>{styles}</>;
   });
 
-  if (typeof window !== 'undefined') return children;
+  if (typeof window !== 'undefined') return <>{children}</>;
 
   return (
     <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>

--- a/app/styling/styled-components/registry.tsx
+++ b/app/styling/styled-components/registry.tsx
@@ -9,7 +9,7 @@ export default function StyledComponentsRegistry({
 }: {
   children: React.ReactNode;
 }) {
-  // Only create stylesheet for once with lazy initial state
+  // Only create stylesheet once with lazy initial state
   // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
   const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
 

--- a/app/styling/styled-components/registry.tsx
+++ b/app/styling/styled-components/registry.tsx
@@ -7,8 +7,10 @@ import { ServerStyleSheet, StyleSheetManager } from 'styled-components';
 export default function StyledComponentsRegistry({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
+  // Only create stylesheet for once with lazy initial state
+  // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
   const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
 
   useServerInsertedHTML(() => {
@@ -16,6 +18,8 @@ export default function StyledComponentsRegistry({
     styledComponentsStyleSheet.instance.clearTag();
     return <>{styles}</>;
   });
+
+  if (typeof window !== 'undefined') return children;
 
   return (
     <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>

--- a/app/styling/styled-jsx/registry.tsx
+++ b/app/styling/styled-jsx/registry.tsx
@@ -7,8 +7,10 @@ import { StyleRegistry, createStyleRegistry } from 'styled-jsx';
 export default function StyledJsxRegistry({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
+  // Only create stylesheet for once with lazy initial state
+  // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
   const [jsxStyleRegistry] = useState(() => createStyleRegistry());
 
   useServerInsertedHTML(() => {

--- a/app/styling/styled-jsx/registry.tsx
+++ b/app/styling/styled-jsx/registry.tsx
@@ -9,7 +9,7 @@ export default function StyledJsxRegistry({
 }: {
   children: React.ReactNode;
 }) {
-  // Only create stylesheet for once with lazy initial state
+  // Only create stylesheet once with lazy initial state
   // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
   const [jsxStyleRegistry] = useState(() => createStyleRegistry());
 


### PR DESCRIPTION
* Add notes for why using `useState` for creating registry instead of `useMemo` since getting feedback that some eslint rule complaining about it
* Don't wrap style manager to children on browser

x-ref: https://github.com/vercel/next.js/issues/43858
x-ref: https://github.com/vercel/next.js/issues/42358
x-ref: https://github.com/vercel/next.js/issues/42526