### PR TITLE
new tab for byline links

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -54,6 +54,7 @@ function Byline() {
         <a
           className="underline decoration-dotted underline-offset-4 hover:text-gray-400"
           href="https://github.com/vercel/app-playground"
+          target="_blank"
         >
           View code
         </a>
@@ -61,6 +62,7 @@ function Byline() {
         <a
           className="underline decoration-dotted underline-offset-4 hover:text-gray-400"
           href="https://vercel.com/templates/next.js/app-directory"
+          target="_blank"
         >
           deploy your own
         </a>


### PR DESCRIPTION
This PR adds `target=_blank` for the byline links as I feel it's preferable in both cases (especially the code view link) to keep the example open at the same time.