### PR TITLE
Use gap property instead of space utility when using flex

### DIFF
--- a/app/error-handling/[categorySlug]/[subCategorySlug]/page.tsx
+++ b/app/error-handling/[categorySlug]/[subCategorySlug]/page.tsx
@@ -11,7 +11,7 @@ export default async function Page({ params }: PageProps) {
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-between  space-x-3">
+      <div className="flex justify-between gap-x-3">
         <h1 className="text-xl font-medium text-gray-400/80">
           {category.name}
         </h1>

--- a/app/error-handling/[categorySlug]/page.tsx
+++ b/app/error-handling/[categorySlug]/page.tsx
@@ -8,7 +8,7 @@ export default async function Page({ params }: PageProps) {
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-between space-x-3">
+      <div className="flex justify-between gap-x-3">
         <h1 className="text-xl font-medium text-gray-400/80">
           All {category.name}
         </h1>

--- a/app/error-handling/page.tsx
+++ b/app/error-handling/page.tsx
@@ -4,7 +4,7 @@ import { ExternalLink } from '#/ui/ExternalLink';
 export default function Page() {
   return (
     <div className="space-y-4">
-      <div className="flex justify-between space-x-3">
+      <div className="flex justify-between gap-x-3">
         <h1 className="text-xl font-medium text-gray-400/80">Error Handling</h1>
 
         <BuggyButton />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,8 +40,8 @@ export default function RootLayout({
 
 function Byline() {
   return (
-    <div className="flex items-center justify-between space-x-4 p-3.5 lg:px-5 lg:py-3">
-      <div className="flex items-center space-x-1.5">
+    <div className="flex items-center justify-between gap-x-4 p-3.5 lg:px-5 lg:py-3">
+      <div className="flex items-center gap-x-1.5">
         <div className="text-sm text-gray-400">By</div>
         <a href="https://vercel.com" title="Vercel">
           <div className="w-16 text-gray-100 hover:text-gray-50">

--- a/app/route-groups/(checkout)/layout.tsx
+++ b/app/route-groups/(checkout)/layout.tsx
@@ -11,7 +11,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     >
       <div className="space-y-9">
         <div className="flex items-center justify-between">
-          <div className="flex items-center space-x-4">
+          <div className="flex items-center gap-x-4">
             <TabNavItem href="/route-groups">Back</TabNavItem>
           </div>
         </div>

--- a/app/streaming/Product.tsx
+++ b/app/streaming/Product.tsx
@@ -23,7 +23,7 @@ export const Product = ({
             width={400}
           />
 
-          <div className="flex space-x-2">
+          <div className="flex gap-x-2">
             <div className="w-1/3">
               <Image
                 src={`/${product.image}`}

--- a/app/streaming/layout.tsx
+++ b/app/streaming/layout.tsx
@@ -15,8 +15,8 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <CartCountProvider initialCartCount={cartCount}>
       <div className="space-y-12 lg:space-y-16">
-        <div className="flex items-center justify-between space-x-3 rounded-lg bg-gray-800 px-3 py-3 lg:px-5 lg:py-4">
-          <div className="flex space-x-3">
+        <div className="flex items-center justify-between gap-x-3 rounded-lg bg-gray-800 px-3 py-3 lg:px-5 lg:py-4">
+          <div className="flex gap-x-3">
             <Link href="/streaming">
               <div className="h-10 w-10">
                 <NextLogo />
@@ -38,7 +38,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             </div>
           </div>
 
-          <div className="flex shrink-0 space-x-3">
+          <div className="flex shrink-0 gap-x-3">
             <div className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gray-600 text-white">
               <ShoppingCartIcon className="w-6 text-white" />
               <div className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-vercel-pink text-sm font-bold text-white">

--- a/ui/AddressBar.tsx
+++ b/ui/AddressBar.tsx
@@ -7,7 +7,7 @@ export function AddressBar() {
   const pathname = usePathname();
 
   return (
-    <div className="flex items-center space-x-2 p-3.5 lg:px-5 lg:py-3">
+    <div className="flex items-center gap-x-2 p-3.5 lg:px-5 lg:py-3">
       <div className="text-gray-600">
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -22,7 +22,7 @@ export function AddressBar() {
           />
         </svg>
       </div>
-      <div className="flex space-x-1 text-sm font-medium">
+      <div className="flex gap-x-1 text-sm font-medium">
         <div>
           <span className="px-2 text-gray-400">acme.com</span>
         </div>

--- a/ui/Boundary.tsx
+++ b/ui/Boundary.tsx
@@ -56,7 +56,7 @@ export const Boundary = ({
     >
       <div
         className={clsx(
-          'absolute -top-2.5 flex space-x-1 text-[9px] uppercase leading-4 tracking-widest',
+          'absolute -top-2.5 flex gap-x-1 text-[9px] uppercase leading-4 tracking-widest',
           {
             'left-3 lg:left-5': size === 'small',
             'left-4 lg:left-9': size === 'default',

--- a/ui/ComponentTree.tsx
+++ b/ui/ComponentTree.tsx
@@ -37,7 +37,7 @@ const List = ({ items, depth }: { items: Item[]; depth: number }) => {
                   )
             }
           >
-            <div className="flex space-x-1">
+            <div className="flex gap-x-1">
               <div
                 className={clsx(
                   'rounded-md px-2 py-0.5 text-xs tracking-wide',
@@ -113,7 +113,7 @@ export const ComponentTree = ({ items }: { items: Item[] }) => {
 
           <div className="space-y-6">
             <div className="space-y-3 rounded-lg bg-gray-900 p-4">
-              <div className="flex items-center justify-between space-x-3">
+              <div className="flex items-center justify-between gap-x-3">
                 <div className="rounded-md bg-vercel-blue px-2 py-0.5 text-xs tabular-nums tracking-wider text-blue-50">
                   <CountUp
                     start={(clientTotal + serverTotal) / 1000}
@@ -137,14 +137,14 @@ export const ComponentTree = ({ items }: { items: Item[] }) => {
             </div>
 
             <div className="space-y-3">
-              <div className="flex items-center space-x-3 text-sm text-gray-400">
+              <div className="flex items-center gap-x-3 text-sm text-gray-400">
                 <div className="rounded-md bg-vercel-blue px-2 py-0.5 text-xs tracking-widest text-white/50">
                   {'</>'}
                 </div>
                 <div>Client Component</div>
               </div>
 
-              <div className="flex items-center space-x-3 text-sm text-gray-400">
+              <div className="flex items-center gap-x-3 text-sm text-gray-400">
                 <div className="rounded-md bg-gray-700 px-2 py-0.5 text-xs tracking-widest text-white/50">
                   {'</>'}
                 </div>

--- a/ui/ExternalLink.tsx
+++ b/ui/ExternalLink.tsx
@@ -10,7 +10,7 @@ export const ExternalLink = ({
   return (
     <a
       href={href}
-      className="inline-flex space-x-2 rounded-lg bg-gray-700 px-3 py-1 text-sm font-medium text-gray-100 hover:bg-gray-500 hover:text-white"
+      className="inline-flex gap-x-2 rounded-lg bg-gray-700 px-3 py-1 text-sm font-medium text-gray-100 hover:bg-gray-500 hover:text-white"
     >
       <div>{children}</div>
 

--- a/ui/Footer.tsx
+++ b/ui/Footer.tsx
@@ -32,7 +32,7 @@ export default function Footer({
         </svg>
       </span>
 
-      <div className="flex space-x-6 text-sm text-gray-600">
+      <div className="flex gap-x-6 text-sm text-gray-600">
         <div>React: {reactVersion}</div>
         <div>Next: {nextVersion}</div>
       </div>

--- a/ui/GlobalNav.tsx
+++ b/ui/GlobalNav.tsx
@@ -17,7 +17,7 @@ export function GlobalNav() {
       <div className="flex h-14 items-center py-4 px-4 lg:h-auto">
         <Link
           href="/"
-          className="group flex w-full items-center space-x-2.5"
+          className="group flex w-full items-center gap-x-2.5"
           onClick={close}
         >
           <div className="h-7 w-7 rounded-full border border-white/30 group-hover:border-white/50">
@@ -31,7 +31,7 @@ export function GlobalNav() {
       </div>
       <button
         type="button"
-        className="group absolute right-0 top-0 flex h-14 items-center space-x-2 px-4 lg:hidden"
+        className="group absolute right-0 top-0 flex h-14 items-center gap-x-2 px-4 lg:hidden"
         onClick={() => setIsOpen(!isOpen)}
       >
         <div className="font-medium text-gray-100 group-hover:text-gray-400">

--- a/ui/MobileNavToggle.tsx
+++ b/ui/MobileNavToggle.tsx
@@ -38,7 +38,7 @@ export function MobileNavToggle({ children }: { children: React.ReactNode }) {
     <>
       <button
         type="button"
-        className="group absolute right-0 top-0 flex h-14 items-center space-x-2 px-4 lg:hidden"
+        className="group absolute right-0 top-0 flex h-14 items-center gap-x-2 px-4 lg:hidden"
         onClick={() => setIsOpen(!isOpen)}
       >
         <div className="font-medium text-gray-100 group-hover:text-gray-400">

--- a/ui/ProductDeal.tsx
+++ b/ui/ProductDeal.tsx
@@ -15,7 +15,7 @@ export const ProductDeal = ({
   const percent = Math.round(100 - (discount / price) * 100);
 
   return (
-    <div className="flex space-x-1.5">
+    <div className="flex gap-x-1.5">
       <div className="text-lg font-bold leading-snug text-vercel-pink">
         -{percent}%
       </div>

--- a/ui/ProductRating.tsx
+++ b/ui/ProductRating.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 
 export const ProductRating = ({ rating }: { rating: number }) => {
   return (
-    <div className="flex space-x-1">
+    <div className="flex gap-x-1">
       {Array.from({ length: 5 }).map((_, i) => {
         return (
           <StarIcon

--- a/ui/ProductReviewCard.tsx
+++ b/ui/ProductReviewCard.tsx
@@ -5,7 +5,7 @@ export const ProductReviewCard = ({ review }: { review: Review }) => {
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <div className="flex items-center space-x-2">
+        <div className="flex items-center gap-x-2">
           <div className="h-6 w-6 rounded-full bg-gray-700" />
           <div className="text-sm text-white">{review.name}</div>
         </div>

--- a/ui/Tab.tsx
+++ b/ui/Tab.tsx
@@ -23,7 +23,7 @@ export const Tab = ({
   return (
     <Link
       href={href}
-      className={clsx('mt-2 mr-2 rounded-lg px-3 py-1 text-sm font-medium', {
+      className={clsx('rounded-lg px-3 py-1 text-sm font-medium', {
         'bg-gray-700 text-gray-100 hover:bg-gray-500 hover:text-white':
           !isActive,
         'bg-vercel-blue text-white': isActive,

--- a/ui/TabGroup.tsx
+++ b/ui/TabGroup.tsx
@@ -7,7 +7,7 @@ export type Item = {
 
 export const TabGroup = ({ path, items }: { path: string; items: Item[] }) => {
   return (
-    <div className="-mt-2 flex flex-wrap items-center">
+    <div className="flex flex-wrap gap-2 items-center">
       {items.map((item) => (
         <Tab key={path + item.slug} item={item} path={path} />
       ))}


### PR DESCRIPTION
I think [93%](https://caniuse.com/flexbox-gap) (all evergreen browsers) global support is okay for a dev focused demo.

`space-x-2`:

```css
.space-x-2 > :not([hidden]) ~ :not([hidden]) {
  --tw-space-x-reverse: 0;
  margin-right: calc(0.5rem * var(--tw-space-x-reverse));
  margin-left: calc(0.5rem * calc(1 - var(--tw-space-x-reverse)));
}
```

`gap-x-2`:

```css
.gap-x-2 {
  column-gap: 0.5rem;
}
```


