### PR TITLE
Create <LinearStream> components that visually streams like PHP

### DIFF
--- a/app/streaming/_components/linear-stream.tsx
+++ b/app/streaming/_components/linear-stream.tsx
@@ -1,5 +1,3 @@
-'use server';
-
 import { Suspense } from 'react';
 
 const hideSuccessors = `*:has(.linearStreamSentitel) ~ *, .linearStreamSentitel ~ *, .linearStreamSentitel {
@@ -10,11 +8,7 @@ const hideSuccessors = `*:has(.linearStreamSentitel) ~ *, .linearStreamSentitel 
  * Streams like in PHP: The component's children and all successors are hidden while we are
  * waiting for the children to finish loading.
  */
-export async function LinearStream({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export function LinearStream({ children }: { children: React.ReactNode }) {
   return (
     <Suspense
       fallback={

--- a/app/streaming/_components/linear-stream.tsx
+++ b/app/streaming/_components/linear-stream.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 
-const hideSuccessors = `*:has(.linearStreamSentitel) ~ *, .linearStreamSentitel ~ *, .linearStreamSentitel {
+const hideSuccessors = `*:has(.linearStreamSentinel) ~ *, .linearStreamSentinel ~ *, .linearStreamSentinel {
   display: none
 }`;
 
@@ -14,7 +14,7 @@ export function LinearStream({ children }: { children: React.ReactNode }) {
       fallback={
         <>
           <style dangerouslySetInnerHTML={{ __html: hideSuccessors }}></style>
-          <div className="linearStreamSentitel" />
+          <div className="linearStreamSentinel" />
         </>
       }
     >

--- a/app/streaming/_components/linear-stream.tsx
+++ b/app/streaming/_components/linear-stream.tsx
@@ -1,0 +1,30 @@
+'use server';
+
+import { Suspense } from 'react';
+
+const hideSuccessors = `*:has(.linearStreamSentitel) ~ *, .linearStreamSentitel ~ *, .linearStreamSentitel {
+  display: none
+}`;
+
+/**
+ * Streams like in PHP: The component's children and all successors are hidden while we are
+ * waiting for the children to finish loading.
+ */
+export async function LinearStream({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <Suspense
+      fallback={
+        <>
+          <style dangerouslySetInnerHTML={{ __html: hideSuccessors }}></style>
+          <div className="linearStreamSentitel" />
+        </>
+      }
+    >
+      {children}
+    </Suspense>
+  );
+}

--- a/app/streaming/edge/layout.tsx
+++ b/app/streaming/edge/layout.tsx
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers';
 import React from 'react';
 import { CartCountProvider } from '../_components/cart-count-context';
 import { Header } from '../_components/header';
+import { LinearStream } from '../_components/linear-stream';
 
 export const metadata = {
   title: 'Streaming (Edge Runtime)',
@@ -33,7 +34,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           <div className="space-y-10">
             <Header />
 
-            {children}
+            <LinearStream>{children}</LinearStream>
           </div>
         </CartCountProvider>
       </Boundary>

--- a/app/streaming/edge/product/[id]/page.tsx
+++ b/app/streaming/edge/product/[id]/page.tsx
@@ -14,7 +14,14 @@ export default async function Page({ params }: { params: { id: string } }) {
     <div className="space-y-8 lg:space-y-14">
       {/* @ts-expect-error Async Server Component */}
       <SingleProduct
-        data={fetch(`https://app-dir.vercel.app/api/products?id=${params.id}`)}
+        data={fetch(
+          `https://app-dir.vercel.app/api/products?delay=3000&id=${params.id}`,
+          {
+            // We intentionally disable Next.js Cache to better demo
+            // streaming
+            cache: 'no-store',
+          },
+        )}
       />
 
       <div className="relative">

--- a/app/streaming/node/layout.tsx
+++ b/app/streaming/node/layout.tsx
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers';
 import React from 'react';
 import { CartCountProvider } from '../_components/cart-count-context';
 import { Header } from '../_components/header';
+import { LinearStream } from '../_components/linear-stream';
 
 export const metadata = {
   title: 'Streaming (Node Runtime)',
@@ -31,8 +32,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <CartCountProvider initialCartCount={cartCount}>
           <div className="space-y-10">
             <Header />
-
-            {children}
+            <LinearStream>{children}</LinearStream>
           </div>
         </CartCountProvider>
       </Boundary>

--- a/app/streaming/node/product/[id]/page.tsx
+++ b/app/streaming/node/product/[id]/page.tsx
@@ -12,7 +12,14 @@ export default async function Page({ params }: { params: { id: string } }) {
     <div className="space-y-8 lg:space-y-14">
       {/* @ts-expect-error Async Server Component */}
       <SingleProduct
-        data={fetch(`https://app-dir.vercel.app/api/products?id=${params.id}`)}
+        data={fetch(
+          `https://app-dir.vercel.app/api/products?delay=3000&id=${params.id}`,
+          {
+            // We intentionally disable Next.js Cache to better demo
+            // streaming
+            cache: 'no-store',
+          },
+        )}
       />
 
       <div className="relative">


### PR DESCRIPTION
In practice it is better than PHP because sibling suspense boundaries can still execute.

I think there is an argument that Next should wrap layout/layout/page boundaries with a component like this. If we don't do that, we should still make a component library that provides reusable non-primitive streaming functionality.