### PR TITLE
Move Byline to sidebar for better visibility

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import '#/styles/globals.css';
 import { AddressBar } from '#/ui/address-bar';
 import { GlobalNav } from '#/ui/global-nav';
-import { VercelLogo } from '#/ui/vercel-logo';
 
 export const metadata = {
   title: {
@@ -34,50 +33,9 @@ export default function RootLayout({
             <div className="rounded-lg bg-vc-border-gradient p-px shadow-lg shadow-black/20">
               <div className="rounded-lg bg-black p-3.5 lg:p-6">{children}</div>
             </div>
-
-            <div className="rounded-lg bg-vc-border-gradient p-px shadow-lg shadow-black/20">
-              <div className="rounded-lg bg-black">
-                <Byline />
-              </div>
-            </div>
           </div>
         </div>
       </body>
     </html>
-  );
-}
-
-function Byline() {
-  return (
-    <div className="flex items-center justify-between gap-x-4 p-3.5 lg:px-5 lg:py-3">
-      <div className="flex items-center gap-x-1.5">
-        <div className="text-sm text-gray-400">By</div>
-        <a href="https://vercel.com" title="Vercel">
-          <div className="w-16 text-gray-100 hover:text-gray-50">
-            <VercelLogo />
-          </div>
-        </a>
-      </div>
-
-      <div className="text-sm text-gray-400">
-        <a
-          className="underline decoration-dotted underline-offset-4 hover:text-gray-400"
-          href="https://github.com/vercel/app-playground"
-          target="_blank"
-          rel="noreferrer"
-        >
-          View code
-        </a>
-        {' or '}
-        <a
-          className="underline decoration-dotted underline-offset-4 hover:text-gray-400"
-          href="https://vercel.com/templates/next.js/app-directory"
-          target="_blank"
-          rel="noreferrer"
-        >
-          deploy your own
-        </a>
-      </div>
-    </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import '#/styles/globals.css';
 import { AddressBar } from '#/ui/address-bar';
+import Byline from '#/ui/byline';
 import { GlobalNav } from '#/ui/global-nav';
 
 export const metadata = {
@@ -33,6 +34,7 @@ export default function RootLayout({
             <div className="rounded-lg bg-vc-border-gradient p-px shadow-lg shadow-black/20">
               <div className="rounded-lg bg-black p-3.5 lg:p-6">{children}</div>
             </div>
+            <Byline className="fixed sm:hidden" />
           </div>
         </div>
       </body>

--- a/ui/byline.tsx
+++ b/ui/byline.tsx
@@ -1,0 +1,40 @@
+import { VercelLogo } from '#/ui/vercel-logo';
+
+export default function Byline({ className }: { className: string }) {
+  return (
+    <div
+      className={`${className} inset-x-0 bottom-3 mx-3 rounded-lg bg-vc-border-gradient p-px shadow-lg shadow-black/20`}
+    >
+      <div className="flex flex-col justify-between space-y-2 rounded-lg bg-black p-3.5 lg:px-5 lg:py-3">
+        <div className="flex items-center gap-x-1.5">
+          <div className="text-sm text-gray-400">By</div>
+          <a href="https://vercel.com" title="Vercel">
+            <div className="w-16 text-gray-100 hover:text-gray-50">
+              <VercelLogo />
+            </div>
+          </a>
+        </div>
+
+        <div className="text-sm text-gray-400">
+          <a
+            className="underline decoration-dotted underline-offset-4 transition-colors hover:text-gray-300"
+            href="https://github.com/vercel/app-playground"
+            target="_blank"
+            rel="noreferrer"
+          >
+            View code
+          </a>
+          {' or '}
+          <a
+            className="underline decoration-dotted underline-offset-4 transition-colors hover:text-gray-300"
+            href="https://vercel.com/templates/next.js/app-directory"
+            target="_blank"
+            rel="noreferrer"
+          >
+            deploy your own
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/global-nav.tsx
+++ b/ui/global-nav.tsx
@@ -7,7 +7,7 @@ import { useSelectedLayoutSegment } from 'next/navigation';
 import { MenuAlt2Icon, XIcon } from '@heroicons/react/solid';
 import clsx from 'clsx';
 import { useState } from 'react';
-import { VercelLogo } from '#/ui/vercel-logo';
+import Byline from './byline';
 
 export function GlobalNav() {
   const [isOpen, setIsOpen] = useState(false);
@@ -68,44 +68,7 @@ export function GlobalNav() {
             );
           })}
         </nav>
-        <Byline />
-      </div>
-    </div>
-  );
-}
-
-function Byline() {
-  return (
-    <div className="absolute inset-x-0 bottom-3 mx-3 rounded-lg bg-vc-border-gradient p-px shadow-lg shadow-black/20">
-      <div className="flex flex-col justify-between space-y-2 rounded-lg bg-black p-3.5 lg:px-5 lg:py-3">
-        <div className="flex items-center gap-x-1.5">
-          <div className="text-sm text-gray-400">By</div>
-          <a href="https://vercel.com" title="Vercel">
-            <div className="w-16 text-gray-100 hover:text-gray-50">
-              <VercelLogo />
-            </div>
-          </a>
-        </div>
-
-        <div className="text-sm text-gray-400">
-          <a
-            className="underline decoration-dotted underline-offset-4 transition-colors hover:text-gray-300"
-            href="https://github.com/vercel/app-playground"
-            target="_blank"
-            rel="noreferrer"
-          >
-            View code
-          </a>
-          {' or '}
-          <a
-            className="underline decoration-dotted underline-offset-4 transition-colors hover:text-gray-300"
-            href="https://vercel.com/templates/next.js/app-directory"
-            target="_blank"
-            rel="noreferrer"
-          >
-            deploy your own
-          </a>
-        </div>
+        <Byline className="absolute hidden sm:block" />
       </div>
     </div>
   );

--- a/ui/global-nav.tsx
+++ b/ui/global-nav.tsx
@@ -7,6 +7,7 @@ import { useSelectedLayoutSegment } from 'next/navigation';
 import { MenuAlt2Icon, XIcon } from '@heroicons/react/solid';
 import clsx from 'clsx';
 import { useState } from 'react';
+import { VercelLogo } from '#/ui/vercel-logo';
 
 export function GlobalNav() {
   const [isOpen, setIsOpen] = useState(false);
@@ -67,6 +68,44 @@ export function GlobalNav() {
             );
           })}
         </nav>
+      </div>
+      <Byline />
+    </div>
+  );
+}
+
+function Byline() {
+  return (
+    <div className="absolute inset-x-0 bottom-3 mx-3 rounded-lg bg-vc-border-gradient p-px shadow-lg shadow-black/20">
+      <div className="flex flex-col justify-between space-y-2 rounded-lg bg-black p-3.5 lg:px-5 lg:py-3">
+        <div className="flex items-center gap-x-1.5">
+          <div className="text-sm text-gray-400">By</div>
+          <a href="https://vercel.com" title="Vercel">
+            <div className="w-16 text-gray-100 hover:text-gray-50">
+              <VercelLogo />
+            </div>
+          </a>
+        </div>
+
+        <div className="text-sm text-gray-400">
+          <a
+            className="underline decoration-dotted underline-offset-4 transition-colors hover:text-gray-300"
+            href="https://github.com/vercel/app-playground"
+            target="_blank"
+            rel="noreferrer"
+          >
+            View code
+          </a>
+          {' or '}
+          <a
+            className="underline decoration-dotted underline-offset-4 transition-colors hover:text-gray-300"
+            href="https://vercel.com/templates/next.js/app-directory"
+            target="_blank"
+            rel="noreferrer"
+          >
+            deploy your own
+          </a>
+        </div>
       </div>
     </div>
   );

--- a/ui/global-nav.tsx
+++ b/ui/global-nav.tsx
@@ -14,7 +14,7 @@ export function GlobalNav() {
   const close = () => setIsOpen(false);
 
   return (
-    <div className="fixed top-0 z-10 flex w-full flex-col border-b border-gray-800 bg-black lg:bottom-0 lg:z-auto lg:w-72 lg:border-r lg:border-gray-800">
+    <div className="fixed top-0 z-10 flex w-full flex-col border-b border-gray-800 bg-black lg:bottom-0 lg:z-auto lg:w-72 lg:border-b-0 lg:border-r lg:border-gray-800">
       <div className="flex h-14 items-center py-4 px-4 lg:h-auto">
         <Link
           href="/"

--- a/ui/global-nav.tsx
+++ b/ui/global-nav.tsx
@@ -68,8 +68,8 @@ export function GlobalNav() {
             );
           })}
         </nav>
+        <Byline />
       </div>
-      <Byline />
     </div>
   );
 }


### PR DESCRIPTION
Before, you had to scroll all the way to the bottom to see the Byline:

![CleanShot 2023-03-15 at 13 18 19](https://user-images.githubusercontent.com/28986134/225405727-a00b97a6-3363-4c7a-ae7b-d96898d76d82.gif)

This PR brings the Byline to the `<GlobalNav />` component to make it more visible:

![CleanShot 2023-03-15 at 13 16 45](https://user-images.githubusercontent.com/28986134/225405797-25daa5e7-a866-424b-afca-736e184d3103.png)

On mobile, it's a nice `fixed` div at the bottom of the screen:

![CleanShot 2023-03-15 at 13 27 56](https://user-images.githubusercontent.com/28986134/225407518-5b4657ea-3bf6-401f-a18c-bdaa42ddb8f8.png)

