### PR TITLE
Add basePath to next.config.js and it breaks on VERCEL

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true, // Recommended for the `pages` directory, default in `app`.
+  basePath: '/app',
   experimental: {
     appDir: true,
   },


### PR DESCRIPTION
Trying to point out that when you DEPLOY TO VERCEL, you cannot soft navigate to dynamic urls. https://github.com/vercel/next.js/issues/48305