### PR TITLE
chore: update docs from beta to stable

### DIFF
--- a/app/context/page.tsx
+++ b/app/context/page.tsx
@@ -18,7 +18,7 @@ export default function Page() {
       </ul>
 
       <div className="flex gap-2">
-        <ExternalLink href="https://beta.nextjs.org/docs/rendering/server-and-client-components#using-context">
+        <ExternalLink href="https://nextjs.org/docs/getting-started/react-essentials#context">
           Docs
         </ExternalLink>
         <ExternalLink href="https://github.com/vercel/app-playground/tree/main/app/context">

--- a/app/error-handling/page.tsx
+++ b/app/error-handling/page.tsx
@@ -22,7 +22,7 @@ export default function Page() {
       <div className="flex gap-2">
         <BuggyButton />
 
-        <ExternalLink href="https://beta.nextjs.org/docs/routing/error-handling">
+        <ExternalLink href="https://nextjs.org/docs/app/building-your-application/routing/error-handling">
           Docs
         </ExternalLink>
         <ExternalLink href="https://github.com/vercel/app-playground/tree/main/app/error-handling">

--- a/app/hooks/page.tsx
+++ b/app/hooks/page.tsx
@@ -19,7 +19,7 @@ export default function Page() {
         </ul>
 
         <div className="flex gap-2">
-          <ExternalLink href="https://beta.nextjs.org/docs/data-fetching/fetching#revalidating-data">
+          <ExternalLink href="https://nextjs.org/docs/app/building-your-application/data-fetching/fetching#revalidating-data">
             Docs
           </ExternalLink>
           <ExternalLink href="https://github.com/vercel/app-playground/tree/main/app/hooks">

--- a/app/isr/page.tsx
+++ b/app/isr/page.tsx
@@ -18,7 +18,7 @@ export default function Page() {
       </ul>
 
       <div className="flex gap-2">
-        <ExternalLink href="https://beta.nextjs.org/docs/data-fetching/fetching#revalidating-data">
+        <ExternalLink href="https://nextjs.org/docs/app/building-your-application/data-fetching/fetching#revalidating-data">
           Docs
         </ExternalLink>
         <ExternalLink href="https://github.com/vercel/app-playground/tree/main/app/isr">

--- a/app/layouts/page.tsx
+++ b/app/layouts/page.tsx
@@ -15,7 +15,7 @@ export default function Page() {
       </ul>
 
       <div className="flex gap-2">
-        <ExternalLink href="https://beta.nextjs.org/docs/routing/pages-and-layouts">
+        <ExternalLink href="https://nextjs.org/docs/app/building-your-application/routing/pages-and-layouts">
           Docs
         </ExternalLink>
         <ExternalLink href="https://github.com/vercel/app-playground/tree/main/app/layouts">

--- a/app/loading/page.tsx
+++ b/app/loading/page.tsx
@@ -23,7 +23,7 @@ export default function Page() {
       </ul>
 
       <div className="flex gap-2">
-        <ExternalLink href="https://beta.nextjs.org/docs/routing/loading-ui">
+        <ExternalLink href="https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming">
           Docs
         </ExternalLink>
         <ExternalLink href="https://github.com/vercel/app-playground/tree/main/app/loading">

--- a/app/not-found/[categorySlug]/[subCategorySlug]/page.tsx
+++ b/app/not-found/[categorySlug]/[subCategorySlug]/page.tsx
@@ -10,7 +10,7 @@ export default async function Page({
   // - `notFound()` renders the closest `not-found.tsx` in the route segment hierarchy.
   // - For `layout.js`, the closest `not-found.tsx` starts from the parent segment.
   // - For `page.js`, the closest `not-found.tsx` starts from the same segment.
-  // - Learn more: https://beta.nextjs.org/docs/routing/fundamentals#component-hierarchy.
+  // - Learn more: https://nextjs.org/docs/app/building-your-application/routing#component-hierarchy.
   const category = await getCategory({ slug: params.subCategorySlug });
 
   return (

--- a/app/not-found/[categorySlug]/layout.tsx
+++ b/app/not-found/[categorySlug]/layout.tsx
@@ -13,7 +13,7 @@ export default async function Layout({
   // - `notFound()` renders the closest `not-found.tsx` in the route segment hierarchy.
   // - For `layout.js`, the closest `not-found.tsx` starts from the parent segment.
   // - For `page.js`, the closest `not-found.tsx` starts from the same segment.
-  // - Learn more: https://beta.nextjs.org/docs/routing/fundamentals#component-hierarchy.
+  // - Learn more: https://nextjs.org/docs/app/building-your-application/routing#component-hierarchy.
   const category = await getCategory({ slug: params.categorySlug });
   const categories = await getCategories({ parent: params.categorySlug });
 

--- a/app/not-found/[categorySlug]/page.tsx
+++ b/app/not-found/[categorySlug]/page.tsx
@@ -10,7 +10,7 @@ export default async function Page({
   // - `notFound()` renders the closest `not-found.tsx` in the route segment hierarchy.
   // - For `layout.js`, the closest `not-found.tsx` starts from the parent segment.
   // - For `page.js`, the closest `not-found.tsx` starts from the same segment.
-  // - Learn more: https://beta.nextjs.org/docs/routing/fundamentals#component-hierarchy.
+  // - Learn more: https://nextjs.org/docs/app/building-your-application/routing#component-hierarchy.
   const category = await getCategory({ slug: params.categorySlug });
 
   return (

--- a/app/not-found/page.tsx
+++ b/app/not-found/page.tsx
@@ -9,13 +9,13 @@ export default function Page() {
       <ul>
         <li>
           <code>
-            <Link href="https://beta.nextjs.org/docs/api-reference/file-conventions/not-found">
+            <Link href="https://nextjs.org/docs/app/api-reference/file-conventions/not-found">
               not-found.js
             </Link>
           </code>{' '}
           file is used to render UI when the{' '}
           <code>
-            <Link href="https://beta.nextjs.org/docs/api-reference/notfound">
+            <Link href="https://nextjs.org/docs/app/api-reference/functions/not-found">
               notFound()
             </Link>
           </code>{' '}
@@ -41,7 +41,7 @@ export default function Page() {
       </ul>
 
       <div className="flex gap-2">
-        <ExternalLink href="https://beta.nextjs.org/docs/api-reference/file-conventions/not-found">
+        <ExternalLink href="https://nextjs.org/docs/app/api-reference/file-conventions/not-found">
           Docs
         </ExternalLink>
 

--- a/app/route-groups/(main)/page.tsx
+++ b/app/route-groups/(main)/page.tsx
@@ -26,7 +26,7 @@ export default function Page() {
       </ul>
 
       <div className="flex gap-2">
-        <ExternalLink href="https://beta.nextjs.org/docs/routing/defining-routes#route-groups">
+        <ExternalLink href="https://nextjs.org/docs/app/building-your-application/routing/route-groups">
           Docs
         </ExternalLink>
         <ExternalLink href="https://github.com/vercel/app-playground/tree/main/app/route-groups">

--- a/app/snippets/search-params/page.tsx
+++ b/app/snippets/search-params/page.tsx
@@ -50,7 +50,7 @@ export default async function Page({ searchParams }: { searchParams: any }) {
             </Suspense>
           </Boundary>
 
-          <ExternalLink href="https://beta.nextjs.org/docs/api-reference/use-search-params">
+          <ExternalLink href="https://nextjs.org/docs/app/api-reference/functions/use-search-params">
             Docs
           </ExternalLink>
         </div>
@@ -95,7 +95,7 @@ export default async function Page({ searchParams }: { searchParams: any }) {
             </div>
           </Boundary>
 
-          <ExternalLink href="https://beta.nextjs.org/docs/api-reference/file-conventions/page">
+          <ExternalLink href="https://nextjs.org/docs/app/api-reference/file-conventions/page">
             Docs
           </ExternalLink>
         </div>

--- a/app/ssg/page.tsx
+++ b/app/ssg/page.tsx
@@ -19,7 +19,7 @@ export default function Page() {
       </ul>
 
       <div className="flex gap-2">
-        <ExternalLink href="https://beta.nextjs.org/docs/data-fetching/fetching#static-data">
+        <ExternalLink href="https://nextjs.org/docs/app/building-your-application/data-fetching/fetching#static-data-fetching">
           Docs
         </ExternalLink>
         <ExternalLink href="https://github.com/vercel/app-playground/tree/main/app/ssg">

--- a/app/ssr/page.tsx
+++ b/app/ssr/page.tsx
@@ -17,7 +17,7 @@ export default function Page() {
       </ul>
 
       <div className="flex gap-2">
-        <ExternalLink href="https://beta.nextjs.org/docs/data-fetching/fetching#dynamic-data">
+        <ExternalLink href="https://nextjs.org/docs/app/building-your-application/data-fetching/fetching#dynamic-data-fetching">
           Docs
         </ExternalLink>
         <ExternalLink href="https://github.com/vercel/app-playground/tree/main/app/ssr">

--- a/app/streaming/_components/add-to-cart.tsx
+++ b/app/streaming/_components/add-to-cart.tsx
@@ -31,7 +31,7 @@ export function AddToCart({ initialCartCount }: { initialCartCount: number }) {
       router.refresh();
 
       // We're working on more fine-grained data mutation and revalidation:
-      // https://beta.nextjs.org/docs/data-fetching/mutating
+      // https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions
     });
   };
 

--- a/app/streaming/page.tsx
+++ b/app/streaming/page.tsx
@@ -26,7 +26,7 @@ export default async function Page() {
       </ul>
 
       <div className="flex gap-2">
-        <ExternalLink href="https://beta.nextjs.org/docs/data-fetching/streaming-and-suspense">
+        <ExternalLink href="https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming">
           Docs
         </ExternalLink>
         <ExternalLink href="https://github.com/vercel/app-playground/tree/main/app/streaming">

--- a/app/styling/page.tsx
+++ b/app/styling/page.tsx
@@ -10,7 +10,7 @@ export default function Page() {
       </ul>
 
       <div className="flex gap-2">
-        <ExternalLink href="https://beta.nextjs.org/docs/styling/css-modules">
+        <ExternalLink href="https://nextjs.org/docs/app/building-your-application/styling/css-modules">
           Docs
         </ExternalLink>
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Next.js App Router Playground
 
-Next.js recently introduced the App Router (beta) with support for:
+Next.js recently introduced the App Router with support for:
 
 - **Layouts:** Easily share UI while preserving state and avoiding re-renders.
 - **Server Components:** Making server-first the default for the most dynamic applications.
@@ -25,7 +25,7 @@ pnpm dev
 
 ## Documentation
 
-https://beta.nextjs.org/docs
+https://nextjs.org/docs
 
 ## Leave Feedback
 

--- a/ui/global-nav.tsx
+++ b/ui/global-nav.tsx
@@ -26,7 +26,7 @@ export function GlobalNav() {
           </div>
 
           <h3 className="font-semibold tracking-wide text-gray-400 group-hover:text-gray-50">
-            App Router <span className="Work in progress">(Beta)</span>
+            App Router
           </h3>
         </Link>
       </div>

--- a/ui/rendered-time-ago.tsx
+++ b/ui/rendered-time-ago.tsx
@@ -42,7 +42,7 @@ export function RenderedTimeAgo({ timestamp }: { timestamp: number }) {
       {msAgo ? (
         <>
           <span
-            // https://beta.reactjs.org/apis/react-dom/hydrate#avoiding-unavoidable-hydration-mismatches
+            // https://react.dev/reference/react-dom/hydrate#suppressing-unavoidable-hydration-mismatch-errors
             suppressHydrationWarning={true}
             className="font-semibold tabular-nums text-gray-900"
           >


### PR DESCRIPTION
App Router is no longer beta and is considered stable since [Next.js 13.4](https://nextjs.org/blog/next-13-4)