### PR TITLE
Fix navbar padding

### DIFF
--- a/ui/global-nav.tsx
+++ b/ui/global-nav.tsx
@@ -51,7 +51,7 @@ export function GlobalNav() {
           hidden: !isOpen,
         })}
       >
-        <nav className="space-y-6 px-2 py-5">
+        <nav className="space-y-6 px-2 pb-24 pt-5">
           {demos.map((section) => {
             return (
               <div key={section.name}>


### PR DESCRIPTION
last two items in nav bar are covered by the `view-code` panel

After
<img width="286" alt="image" src="https://github.com/vercel/app-playground/assets/4800338/f58bb7f5-753f-4bdc-a7f9-242d0a987408">

Before
<img width="288" alt="image" src="https://github.com/vercel/app-playground/assets/4800338/c61aebc5-7102-499b-b315-2223137765eb">
