### PR TITLE
fix: fix wrong api endpoint for fetching product detail

### DIFF
--- a/app/streaming/_components/pricing.tsx
+++ b/app/streaming/_components/pricing.tsx
@@ -29,7 +29,7 @@ function LoadingDots() {
 
 async function UserSpecificDetails({ productId }: { productId: string }) {
   const data = await fetch(
-    `https://app-dir.vercel.app/api/products?id=${productId}&delay=500&filter=price,usedPrice,leadTime,stock`,
+    `https://app-router-api.vercel.app/api/products?id=${productId}&delay=500&filter=price,usedPrice,leadTime,stock`,
     {
       // We intentionally disable Next.js Cache to better demo
       // streaming


### PR DESCRIPTION
The api endpoint in `UserSpecificDetails` is wrong, and it result for the  error in official demo : https://app-router.vercel.app/streaming

before:
<img width="1006" alt="image" src="https://github.com/vercel/app-playground/assets/8624194/723c5301-3eb8-4a4a-b5d2-d7d7f48006d7">

after:
<img width="1445" alt="image" src="https://github.com/vercel/app-playground/assets/8624194/ea19d5a6-b1c0-41f2-9dd4-bc8c832546c2">
