### PR TITLE
chore(prettier): Ignore package manager lock files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,2 @@
 .next
-package-lock.json
 pnpm-lock.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
 .next
+package-lock.json
+pnpm-lock.yaml


### PR DESCRIPTION
I was seeing these files hanging prettier.

From quick testing I am seeing the following improvements when running `npm run prettier`

Before:

`npm run prettier  5.10s user 0.61s system 71% cpu 8.041 total`

After:

`npm run prettier  2.45s user 0.38s system 119% cpu 2.363 total`

I was surprised to see that prettier doesn't automatically ignore these files.