### PR TITLE
Fix duplicate React key props in breadcrumbs component

### DIFF
--- a/app/_patterns/breadcrumbs/_components/breadcrumbs.tsx
+++ b/app/_patterns/breadcrumbs/_components/breadcrumbs.tsx
@@ -17,7 +17,6 @@ export function Breadcrumbs({
             )}
 
             <Link
-              key={item.href}
               href={item.href}
               className="text-white capitalize hover:text-gray-500"
             >


### PR DESCRIPTION
## Summary
• Fix duplicate React key props in breadcrumbs component that was causing console warnings
• Remove redundant key prop from Link element when Fragment already has the key
• Resolves "Each child in a list should have a unique key prop" warning on parallel-routes page

## Test plan
- [x] Navigate to `/parallel-routes` page 
- [x] Verify console warning is no longer present
- [x] Confirm breadcrumbs navigation still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)