### PR TITLE
Fix duplicate React key in breadcrumbs and correct re-render color in layouts readme

### DIFF
--- a/app/_patterns/breadcrumbs/_components/breadcrumbs.tsx
+++ b/app/_patterns/breadcrumbs/_components/breadcrumbs.tsx
@@ -17,7 +17,6 @@ export function Breadcrumbs({
             )}
 
             <Link
-              key={item.href}
               href={item.href}
               className="text-white capitalize hover:text-gray-500"
             >

--- a/app/layouts/readme.mdx
+++ b/app/layouts/readme.mdx
@@ -5,7 +5,7 @@ A layout is UI that is shared between multiple routes. On navigation, layouts pr
 ### Demo
 
 1. Try navigating between categories and sub categories above.
-2. Notice layouts do not re-render (visualized as the a pink border animating to gray) when navigating across sibling routes.
+2. Notice layouts do not re-render (visualized as a blue border animating to gray) when navigating across sibling routes.
 3. Notice client state (visualized as a click counter) is preserved between navigations.
 4. Notice you can interact (e.g. click the counter) with the layout while a sibling route is loading.
 


### PR DESCRIPTION
- Remove redundant `key` prop from `<Link>` inside breadcrumbs — the wrapping `<Fragment>` already has the key, causing a duplicate key warning
- Fix 'pink' → 'blue' in layouts readme to match the actual `text-blue-600` rerender animation color
- Fix 'the a' → 'a' typo in the same line
- Bump Next.js to 16.3.0-canary.29

Supersedes #200 and #202.